### PR TITLE
Fix allowed_origins property

### DIFF
--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -29,9 +29,16 @@ class Settings(BaseSettings):
 
     @property
     def allowed_origins_list(self) -> list[str]:
+        """Return CORS origins as a list.
+
+        Pydantic will populate ``allowed_origins`` from the ``ALLOWED_ORIGINS``
+        environment variable. The attribute name is ``allowed_origins`` in the
+        model, therefore we should reference that attribute here. Using the
+        upper‑case variant would raise ``AttributeError`` at runtime.
+        """
         return [
             origin.strip()
-            for origin in self.ALLOWED_ORIGINS.split(",")
+            for origin in self.allowed_origins.split(",")
             if origin.strip()
         ]
 


### PR DESCRIPTION
## Summary
- fix broken `allowed_origins_list` helper

## Testing
- `python -m py_compile services/api/app/config.py`
- `python -m py_compile services/api/app/*.py`
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: cannot find module 'next')*

------
https://chatgpt.com/codex/tasks/task_e_68403008a9c88322a6a862976aaf1984