### PR TITLE
Fix TypeScript issues and align menu interfaces

### DIFF
--- a/services/web/app/src/app/(admin)/admin/dishes/page.tsx
+++ b/services/web/app/src/app/(admin)/admin/dishes/page.tsx
@@ -26,7 +26,15 @@ import { getAllergens } from '@/services/allergenService';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
-const dishTypes: Array<Dish['type']> = ['carne', 'peixe', 'vegetariano', 'vegan', 'sobremesa', 'sopa', 'bebida'];
+const dishTypes = [
+  'carne',
+  'peixe',
+  'vegetariano',
+  'vegan',
+  'sobremesa',
+  'sopa',
+  'bebida',
+] as const;
 
 // Schema for form data, ensures price and kcals are numbers
 const dishFormSchema = z.object({
@@ -278,7 +286,12 @@ export default function DishesPage() {
                       <div className="flex flex-wrap gap-1">
                         {dishAllergensToDisplay.slice(0,3).map(allergen => {
                            const AllergenSpecificIcon = getAllergenIcon(allergen.icon || allergen.name);
-                           return <AllergenSpecificIcon key={allergen.id} className="h-4 w-4" title={allergen.name} />;
+                           return (
+                             <AllergenSpecificIcon
+                               key={allergen.id}
+                               className="h-4 w-4"
+                             />
+                           );
                         })}
                         {dishAllergensToDisplay.length > 3 && <span className="text-xs">+{dishAllergensToDisplay.length-3}</span>}
                         {dishAllergensToDisplay.length === 0 && <span className="text-xs text-muted-foreground">N/A</span>}

--- a/services/web/app/src/app/(admin)/admin/menus/page.tsx
+++ b/services/web/app/src/app/(admin)/admin/menus/page.tsx
@@ -139,7 +139,7 @@ const handleEditMeal = (date: string, mealType: "lunch" | "dinner") => {
 
 const day = weeklyMenu?.days.find((d) => d.date === date);
 const meal: MenuEntry | undefined =
-  mealType === "lunch" ? day?.lunchEntry ?? undefined : day?.dinnerEntry ?? undefined;
+  mealType === "lunch" ? day?.lunch ?? undefined : day?.dinner ?? undefined;
 
 
   const baseForm: MenuDayEditFormData = {
@@ -189,7 +189,8 @@ const meal: MenuEntry | undefined =
 
     const payload: MenuEntryUpdatePayload = {
       date: currentEditForm.date,
-      mealType: currentEditForm.mealType,
+      mealType:
+        currentEditForm.mealType === "lunch" ? "almoco" : "jantar",
       sopaId: currentEditForm.sopaId ?? null,
       mainDishId: currentEditForm.mainDishId,
       altDishId: currentEditForm.altDishId ?? null,
@@ -321,7 +322,7 @@ const meal: MenuEntry | undefined =
               </CardHeader>
               <CardContent className="space-y-4">
                 {(["lunch", "dinner"] as const).map((mealType) => {
-const meal = mealType === "lunch" ? day.lunchEntry : day.dinnerEntry;
+const meal = mealType === "lunch" ? day.lunch : day.dinner;
 
                   return (
                     <div

--- a/services/web/app/src/app/(public)/menu/page.tsx
+++ b/services/web/app/src/app/(public)/menu/page.tsx
@@ -199,9 +199,8 @@ const filteredMenu = useMemo(() => {
     ...weeklyMenu,
     days: weeklyMenu.days.map((day) => ({
       ...day,
-      // 🔄 renomeamos aqui
-      lunch:  filterMenuEntry(day.lunchEntry),
-      dinner: filterMenuEntry(day.dinnerEntry),
+      lunch:  filterMenuEntry(day.lunch),
+      dinner: filterMenuEntry(day.dinner),
     })),
   };
 }, [weeklyMenu, selectedAllergens]);

--- a/services/web/app/src/lib/types.ts
+++ b/services/web/app/src/lib/types.ts
@@ -27,6 +27,8 @@ export interface Dish {
   kcals?: number | null;
   allergenIds?: string[];
   allergens?: Allergen[];
+  /** Optional icon to visually represent the dish */
+  icon?: LucideIcon;
 }
 
 export interface MenuEntry {
@@ -50,12 +52,12 @@ export interface MenuEntry {
 }
 
 export interface DayMenu {
-  date: string; // YYYY-MM-DD
-  weeklyMenuId: string;
-  lunchEntryId?: string | null;
-  dinnerEntryId?: string | null;
-  lunchEntry?: MenuEntry | null;
-  dinnerEntry?: MenuEntry | null;
+  /** ISO date string identifying the day */
+  date: string;
+  /** Lunch menu for the day */
+  lunch?: MenuEntry;
+  /** Dinner menu for the day */
+  dinner?: MenuEntry;
 }
 
 export interface WeeklyMenu {

--- a/services/web/app/src/services/menuService.ts
+++ b/services/web/app/src/services/menuService.ts
@@ -39,7 +39,8 @@ export const getAdminWeeklyMenu = async (): Promise<WeeklyMenu> => {
 // The MenuEntry type might be simplified for the payload, e.g. sending only IDs
 export type MenuEntryUpdatePayload = {
   date: string; // YYYY-MM-DD
-  mealType: 'lunch' | 'dinner';
+  /** Meal type must follow API convention */
+  mealType: 'almoco' | 'jantar';
   sopaId?: string | null; // Use null to clear
   mainDishId: string;
   altDishId?: string | null; // Use null to clear


### PR DESCRIPTION
## Summary
- add optional `icon` field to `Dish`
- simplify `DayMenu` interface and adapt components
- fix enum typing for dish types
- adjust allergen icons
- align menu service with API meal type values

## Testing
- `npm run typecheck`
- `npm run lint` *(fails due to missing ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6840a97d174c8322b6fbe9e49d86059b