### PR TITLE
Fix React forms to match API schemas

### DIFF
--- a/services/web/app/package-lock.json
+++ b/services/web/app/package-lock.json
@@ -5090,9 +5090,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -9234,9 +9234,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/services/web/app/src/app/(admin)/admin/allergens/page.tsx
+++ b/services/web/app/src/app/(admin)/admin/allergens/page.tsx
@@ -63,7 +63,12 @@ export default function AllergensPage() {
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, data }: { id: string, data: AllergenFormData }) => updateAllergen(id, data),
+    mutationFn: ({ id, data }: { id: string, data: AllergenFormData }) =>
+      updateAllergen(id, {
+        name: data.name,
+        icon: data.icon,
+        description: data.description,
+      }),
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['allergens'] });
       toast({ title: "Alérgeno Atualizado", description: `O alérgeno "${data.name}" foi atualizado.`});
@@ -103,7 +108,8 @@ export default function AllergensPage() {
     if (editingAllergen && editingAllergen.id) {
       updateMutation.mutate({ id: editingAllergen.id, data });
     } else {
-      createMutation.mutate(data);
+      const payload = { ...data, id: crypto.randomUUID() };
+      createMutation.mutate(payload);
     }
   };
 

--- a/services/web/app/src/services/allergenService.ts
+++ b/services/web/app/src/services/allergenService.ts
@@ -7,7 +7,7 @@ export const getAllergens = async (): Promise<Allergen[]> => {
   return response.data;
 };
 
-export const createAllergen = async (allergenData: Omit<Allergen, 'id'>): Promise<Allergen> => {
+export const createAllergen = async (allergenData: Allergen): Promise<Allergen> => {
   const response = await apiClient.post('/allergens/', allergenData);
   return response.data;
 };

--- a/services/web/app/src/services/menuService.ts
+++ b/services/web/app/src/services/menuService.ts
@@ -31,9 +31,9 @@ export const listWeeklyMenus = async (): Promise<WeeklyMenu[]> => {
 
 // Example for admin-specific fetching if needed, may require authentication
 export const getAdminWeeklyMenu = async (): Promise<WeeklyMenu> => {
-  const { data } = await apiClient.get('/menus/weekly-admin/'); // Placeholder, adjust to actual admin endpoint
-  // Guarantee a valid array to avoid runtime errors when mapping over days
-  return { ...data, days: data.days ?? [] };
+  const { data } = await apiClient.get('/menus/weekly-admin/');
+  const weekly = Array.isArray(data) ? data[0] : data;
+  return { ...weekly, days: weekly?.days ?? [] };
 };
 
 // Assuming an endpoint for updating a specific meal in a day menu


### PR DESCRIPTION
## Summary
- parse admin weekly menu response correctly when API returns an array
- require ID when creating an allergen and generate UUID in form
- update allergen update mutation to send only updatable fields

## Testing
- `npm run typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684feb26d29c83229c241e06c7ce1222